### PR TITLE
feat(feedback): log structured user feedback into signal_history.jsonl

### DIFF
--- a/src/feedback_router.py
+++ b/src/feedback_router.py
@@ -1,10 +1,10 @@
-# src/feedback_router.py
-
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from datetime import datetime
 import logging
+
+from src.signal_log import log_signal  # ✅ NEW
 
 router = APIRouter()
 logging.basicConfig(level=logging.INFO)
@@ -29,9 +29,23 @@ async def options_feedback():
 
 @router.post("/feedback")
 async def receive_feedback(feedback: Feedback):
+    log_data = {
+        "type": "user_feedback",
+        "timestamp": datetime.utcnow().isoformat(),
+        "asset": feedback.asset,
+        "sentiment": feedback.sentiment,
+        "user_feedback": feedback.user_feedback,
+        "context": feedback.context,
+        "source": "frontend"
+    }
+
     logging.info({
         "event": "user_feedback_received",
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": log_data["timestamp"],
         "data": feedback.dict()
     })
-    return {"status": "received", "received_at": datetime.utcnow().isoformat()}
+
+    # ✅ Log feedback to signal_history.jsonl
+    log_signal(log_data)
+
+    return {"status": "received", "received_at": log_data["timestamp"]}


### PR DESCRIPTION
This PR enables the logging of all user-submitted feedback into the central signal_history.jsonl file. It supports downstream auditability, training dataset generation, and fine-tuning readiness.

What’s included:

Extended POST /feedback to call log_signal(...)

Each feedback entry includes:

type: "user_feedback"

asset, sentiment, user_feedback, context

timestamp (UTC), source: "frontend"

Follows JSONL format alongside existing signal logs

Why it matters:

Creates a unified signal+feedback log

Enables supervised ML training on real user overrides

Tracks context, confidence, and user sentiment for future trust scoring

Tested:

✅ HTTPBot test confirmed 200 OK with expected fields

✅ Log structure verified

✅ Non-blocking to existing feedback pipeline

