### PR TITLE
Add export endpoint for retrain queue with filters and JSON option

### DIFF
--- a/src/internal_router.py
+++ b/src/internal_router.py
@@ -1,21 +1,22 @@
 # src/internal_router.py
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 from collections import defaultdict
 from typing import List, Optional
 from fastapi.responses import JSONResponse, StreamingResponse
+from datetime import datetime
 import json
 import os
 import requests
-from datetime import datetime
+from pathlib import Path
 from src.signal_utils import compute_trust_scores
 
 router = APIRouter(prefix="/internal", tags=["internal-tools"])
 
 FEEDBACK_LOG_PATH = "data/feedback.jsonl"
-SUPPRESSION_REVIEW_PATH = "data/suppression_review_queue.jsonl"
-RETRAIN_QUEUE_PATH = "data/retrain_queue.jsonl"
+SUPPRESSION_REVIEW_PATH = Path("data/suppression_review_queue.jsonl")
+RETRAIN_QUEUE_PATH = Path("data/retrain_queue.jsonl")
 
 # === Feedback Summary Route ===
 @router.get("/feedback-summary")
@@ -79,11 +80,11 @@ def signal_trust_insights():
 # === Suppression Review Queue Route ===
 @router.get("/review-suppressed")
 def review_suppressed_signals():
-    if not os.path.exists(SUPPRESSION_REVIEW_PATH):
+    if not SUPPRESSION_REVIEW_PATH.exists():
         return {"review_queue": []}
 
     pending_signals = []
-    with open(SUPPRESSION_REVIEW_PATH, "r") as f:
+    with SUPPRESSION_REVIEW_PATH.open("r") as f:
         for line in f:
             try:
                 entry = json.loads(line)
@@ -104,13 +105,13 @@ def mark_suppressed(update: SuppressionUpdate):
     if update.new_status not in ["reviewed", "flag_for_retraining"]:
         raise HTTPException(status_code=400, detail="Invalid status")
 
-    if not os.path.exists(SUPPRESSION_REVIEW_PATH):
+    if not SUPPRESSION_REVIEW_PATH.exists():
         raise HTTPException(status_code=404, detail="No suppression file found")
 
     updated_entries = []
     updated = False
 
-    with open(SUPPRESSION_REVIEW_PATH, "r") as f:
+    with SUPPRESSION_REVIEW_PATH.open("r") as f:
         for line in f:
             try:
                 entry = json.loads(line)
@@ -124,11 +125,89 @@ def mark_suppressed(update: SuppressionUpdate):
     if not updated:
         raise HTTPException(status_code=404, detail="Pending signal not found")
 
-    with open(SUPPRESSION_REVIEW_PATH, "w") as f:
+    with SUPPRESSION_REVIEW_PATH.open("w") as f:
         for entry in updated_entries:
             f.write(json.dumps(entry) + "\n")
 
     return {"updated": True, "signal_id": update.signal_id, "new_status": update.new_status}
+
+# === Batch Flag Suppressed Signals for Retraining ===
+class BatchFlagFilters(BaseModel):
+    retrain_hint: str | None = None
+    asset: str | None = None
+    trust_score_below: float | None = None
+
+class BatchFlagRequest(BaseModel):
+    filters: BatchFlagFilters
+    note: str | None = None
+
+@router.post("/batch-flag-retraining")
+def batch_flag_retraining(payload: BatchFlagRequest, dry_run: bool = Query(False)):
+    filters = payload.filters
+    note = payload.note or ""
+
+    batch_flagged = 0
+    skipped_duplicates = 0
+    flagged_ids = set()
+
+    retrain_existing_ids = set()
+    if RETRAIN_QUEUE_PATH.exists():
+        with RETRAIN_QUEUE_PATH.open("r") as f:
+            for line in f:
+                try:
+                    retrain_existing_ids.add(json.loads(line)["id"])
+                except:
+                    continue
+
+    to_append = []
+
+    if SUPPRESSION_REVIEW_PATH.exists():
+        with SUPPRESSION_REVIEW_PATH.open("r") as f:
+            for line in f:
+                try:
+                    entry = json.loads(line)
+                except:
+                    continue
+
+                if entry.get("status") != "pending":
+                    continue
+
+                if filters.retrain_hint and entry.get("retrain_hint") != filters.retrain_hint:
+                    continue
+                if filters.asset and entry.get("asset") != filters.asset:
+                    continue
+                if filters.trust_score_below is not None and entry.get("trust_score", 1.0) >= filters.trust_score_below:
+                    continue
+
+                if entry["id"] in retrain_existing_ids or entry["id"] in flagged_ids:
+                    skipped_duplicates += 1
+                    continue
+
+                flagged_ids.add(entry["id"])
+
+                enriched = {
+                    **entry,
+                    "flagged_for_retraining": True,
+                    "flag_reason": "batch_filter",
+                    "flag_source": "batch_route",
+                    "flagged_at": datetime.utcnow().isoformat(),
+                    "note": note
+                }
+
+                to_append.append(enriched)
+
+    if not dry_run and to_append:
+        os.makedirs(RETRAIN_QUEUE_PATH.parent, exist_ok=True)
+        with RETRAIN_QUEUE_PATH.open("a") as f:
+            for item in to_append:
+                f.write(json.dumps(item) + "\n")
+
+    return {
+        "batch_flagged": len(to_append),
+        "skipped_duplicates": skipped_duplicates,
+        "filters_applied": filters.dict(),
+        "dry_run": dry_run
+    }
 
 # === Export Retrain Queue ===
 @router.get("/export-retrain-queue")
@@ -138,7 +217,7 @@ def export_retrain_queue(
     limit: Optional[int] = Query(None),
     as_file: Optional[bool] = Query(False)
 ):
-    if not os.path.exists(RETRAIN_QUEUE_PATH):
+    if not RETRAIN_QUEUE_PATH.exists():
         return {"exported": 0, "signals": []}
 
     signals_by_id = {}


### PR DESCRIPTION
Reads from data/retrain_queue.jsonl
Deduplicates signs by id
Returns JSON by default
Optional query parameters: 
-asset = BTC - filter by asset
-hint = low_confidence - filter by retrain hint
- limit=100 max # of signals returned
- as_file=true - returns downloadable .jsonl stream