### PR TITLE
feat: tag model version in inference outputs

### DIFF
--- a/scripts/mw_demo_summary.py
+++ b/scripts/mw_demo_summary.py
@@ -1406,6 +1406,7 @@ try:
                 "volatility_regime": "calm",
                 "drifted_features": ["burst_z"],
                 "top_contributors": ["burst_z", "leadership_max_r", "precision_7d"],
+                "model_version": "v0.5.1",
             },
             {
                 "timestamp": (now - timedelta(minutes=40)).isoformat().replace("+00:00", "Z"),
@@ -1416,6 +1417,7 @@ try:
                 "volatility_regime": "turbulent",
                 "drifted_features": [],
                 "top_contributors": ["count_72h", "count_24h", "count_6h"],
+                "model_version": "v0.5.1",
             },
             {
                 "timestamp": (now - timedelta(minutes=65)).isoformat().replace("+00:00", "Z"),
@@ -1426,6 +1428,7 @@ try:
                 "volatility_regime": "normal",
                 "drifted_features": ["burst_z"],
                 "top_contributors": ["burst_z", "precision_7d", "recall_7d"],
+                "model_version": "v0.5.1",
             },
         ]
         # Best-effort: write them to the history file so future runs see them
@@ -1465,8 +1468,12 @@ try:
             regime = (e.get("volatility_regime") or e.get("regime") or "normal")
             drift = e.get("drifted_features") or []
             drift_txt = ", ".join(drift) if isinstance(drift, list) and drift else "none"
-
-            md.append(f"- [{hhmm}] {origin} → {icon} {decision} @ {adj:.2f} (thr={thr:.2f}) — {regime}, drift: {drift_txt}")
+            mv = (e.get("model_version") or "unknown")
+            line = (
+                f"[{hhmm}] {origin} (v{mv}) → {icon} {decision} "
+                f"@ {adj:.2f} (thr={thr:.2f}) — {regime}, drift: {drift_txt}"
+            )
+            md.append(f"- {line}")
 except Exception as e:
     md.append(f"⚠️ Trigger history failed: {e}")
 

--- a/src/ml/infer.py
+++ b/src/ml/infer.py
@@ -23,6 +23,15 @@ _GB_MODEL   = "trigger_likelihood_gb.joblib"
 _GB_META    = "trigger_likelihood_gb.meta.json"
 _TRIGGER_LOG_PATH = Path(os.getenv("TRIGGER_LOG_PATH", MODELS_DIR / "trigger_history.jsonl"))
 
+# --- model version helper ---
+def _read_model_version(path: Path | None = None) -> str:
+    try:
+        base = path or MODELS_DIR
+        v = (base / "training_version.txt").read_text().strip()
+        return v or "unknown"
+    except Exception:
+        return "unknown"
+
 
 
 # ---------- loaders ----------
@@ -103,20 +112,28 @@ def infer_score(payload: Dict[str, Any], *, explain: bool = False, top_n: int = 
         if payload.get("features"):
             bz = float(payload["features"].get("burst_z", 0.0))
             p = 1 / (1 + np.exp(-0.1 * bz))
-            res = {"prob_trigger_next_6h": float(p), "demo": True}
-            if explain:
-                res["contributions"] = {"burst_z": 0.1 * bz}
+            res = {
+                "prob_trigger_next_6h": float(p),
+                "demo": True,
+                **({"contributions": {"burst_z": 0.1 * bz}} if explain else {}),
+                "model_version": _read_model_version(),
+            }
             return res
-        return {"prob_trigger_next_6h": 0.062, "demo": True}
+        return {"prob_trigger_next_6h": 0.062, "demo": True, "model_version": _read_model_version()}
 
     feats = payload.get("features")
     if feats is None:
-        return {"prob_trigger_next_6h": 0.062, "note": "origin path not wired", "demo": meta.get("demo", False)}
+        return {
+            "prob_trigger_next_6h": 0.062,
+            "note": "origin path not wired",
+            "demo": meta.get("demo", False),
+            "model_version": _read_model_version(),
+        }
 
     feat_order = meta.get("feature_order") or []
     x = _vectorize(feats, feat_order)
     proba = float(model.predict_proba(x)[0, 1])
-    out = {"prob_trigger_next_6h": proba}
+    out = {"prob_trigger_next_6h": proba, "model_version": _read_model_version()}
     if explain:
         out["contributions"] = _contributions_linear(model, x, feat_order, top_n=top_n)
     return out
@@ -166,6 +183,7 @@ def infer_score_ensemble(payload: Dict[str, Any], *, models_dir: Path | None = N
     low = float(min(probs))
     high = float(max(probs))
 
+    mv = _read_model_version()
     return {
         "prob_trigger_next_6h": mean,
         "low": low,
@@ -173,26 +191,8 @@ def infer_score_ensemble(payload: Dict[str, Any], *, models_dir: Path | None = N
         "votes": votes,
         "models": list(votes.keys()),
         "demo": demo,
+        "model_version": mv,
     }
-
-        # --- Append to trigger history log ---
-    try:
-        entry = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "origin": payload.get("origin", "unknown"),
-            "adjusted_score": out.get("explanation", {}).get("adjusted_score", out["prob_trigger_next_6h"]),
-            "threshold": out.get("explanation", {}).get("threshold_after_volatility", None),
-            "decision": out.get("explanation", {}).get("decision", "unknown"),
-            "volatility_regime": out.get("explanation", {}).get("volatility_regime", None),
-            "drifted_features": out.get("explanation", {}).get("drifted_features", []),
-            "top_contributors": out.get("explanation", {}).get("top_contributors", []),
-        }
-        with _TRIGGER_LOG_PATH.open("a") as f:
-            f.write(json.dumps(entry) + "\n")
-    except Exception:
-        pass
-
-
 
 # ---------- Volatility-aware thresholds ----------
 def compute_volatility_adjusted_threshold(base_threshold: float, regime: str) -> Dict[str, Any]:

--- a/src/ml/retrain_from_log.py
+++ b/src/ml/retrain_from_log.py
@@ -108,6 +108,13 @@ def _git_sha() -> str | None:
         return None
 
 
+def _write_training_version_txt(version: str, models_dir: Path = MODELS_DIR) -> None:
+    try:
+        (models_dir / "training_version.txt").write_text((version or "unknown").strip() + "\n")
+    except Exception:
+        pass
+
+
 # ------------------------- training core -------------------------
 
 def _train_logistic(
@@ -270,6 +277,9 @@ def retrain_from_log(
                 fdst.write(fsrc.read())
         except Exception:
             pass
+
+    if ver:
+        _write_training_version_txt(ver, out_root)
 
     # ---- compact summary (returned) ----
     summary = {


### PR DESCRIPTION
## Summary
- add helper to read model training version and include it in inference outputs and trigger history
- write training_version.txt during retrain and show version in demo trigger history
- remove unreachable trigger history logging code

## Testing
- `PYTHONPATH=. pytest` *(fails: AttributeError: 'FileFinder' object has no attribute 'find_module' due to outdated snscrape)*
- `pip install --upgrade snscrape` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c105a43bc4832ba4ebeb653bf37fc4