### PR TITLE
Record model version and log with inference

### DIFF
--- a/scripts/mw_demo_summary.py
+++ b/scripts/mw_demo_summary.py
@@ -1396,6 +1396,11 @@ try:
     # DEMO seeding if empty
     if not entries and is_demo_mode():
         now = datetime.now(timezone.utc)
+        ver = os.getenv("MODEL_VERSION", "v0.5.0")
+        try:
+            ver = (MODELS_DIR / "training_version.txt").read_text().strip() or ver
+        except Exception:
+            pass
         sample_entries = [
             {
                 "timestamp": (now - timedelta(minutes=15)).isoformat().replace("+00:00", "Z"),
@@ -1406,6 +1411,7 @@ try:
                 "volatility_regime": "calm",
                 "drifted_features": ["burst_z"],
                 "top_contributors": ["burst_z", "leadership_max_r", "precision_7d"],
+                "model_version": ver,
             },
             {
                 "timestamp": (now - timedelta(minutes=40)).isoformat().replace("+00:00", "Z"),
@@ -1416,6 +1422,7 @@ try:
                 "volatility_regime": "turbulent",
                 "drifted_features": [],
                 "top_contributors": ["count_72h", "count_24h", "count_6h"],
+                "model_version": ver,
             },
             {
                 "timestamp": (now - timedelta(minutes=65)).isoformat().replace("+00:00", "Z"),
@@ -1426,6 +1433,7 @@ try:
                 "volatility_regime": "normal",
                 "drifted_features": ["burst_z"],
                 "top_contributors": ["burst_z", "precision_7d", "recall_7d"],
+                "model_version": ver,
             },
         ]
         # Best-effort: write them to the history file so future runs see them

--- a/src/ml/infer.py
+++ b/src/ml/infer.py
@@ -48,6 +48,14 @@ def _load_cov(models_dir: Path | None = None) -> Dict[str, Any]:
         return {}
 
 
+def _read_model_version(models_dir: Path | None = None) -> str:
+    path = (models_dir or MODELS_DIR) / "training_version.txt"
+    try:
+        return path.read_text(encoding="utf-8").strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
 # ---------- public metadata helpers ----------
 def model_metadata(models_dir: Path | None = None) -> Dict[str, Any]:
     """Logistic metadata (+ coverage merged) for back-compat."""
@@ -165,8 +173,7 @@ def infer_score_ensemble(payload: Dict[str, Any], *, models_dir: Path | None = N
     mean = float(np.mean(probs))
     low = float(min(probs))
     high = float(max(probs))
-
-    return {
+    out = {
         "prob_trigger_next_6h": mean,
         "low": low,
         "high": high,
@@ -175,7 +182,7 @@ def infer_score_ensemble(payload: Dict[str, Any], *, models_dir: Path | None = N
         "demo": demo,
     }
 
-        # --- Append to trigger history log ---
+    # --- Append to trigger history log ---
     try:
         entry = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -186,11 +193,14 @@ def infer_score_ensemble(payload: Dict[str, Any], *, models_dir: Path | None = N
             "volatility_regime": out.get("explanation", {}).get("volatility_regime", None),
             "drifted_features": out.get("explanation", {}).get("drifted_features", []),
             "top_contributors": out.get("explanation", {}).get("top_contributors", []),
+            "model_version": _read_model_version(models_dir),
         }
         with _TRIGGER_LOG_PATH.open("a") as f:
             f.write(json.dumps(entry) + "\n")
     except Exception:
         pass
+
+    return out
 
 
 

--- a/src/ml/retrain_from_log.py
+++ b/src/ml/retrain_from_log.py
@@ -271,6 +271,14 @@ def retrain_from_log(
         except Exception:
             pass
 
+    # Record the training version for inference to reference later
+    try:
+        ver_file = out_root / "training_version.txt"
+        ver_file.parent.mkdir(parents=True, exist_ok=True)
+        ver_file.write_text(ver, encoding="utf-8")
+    except Exception:
+        pass
+
     # ---- compact summary (returned) ----
     summary = {
         "version": ver,

--- a/tests/test_training_version.py
+++ b/tests/test_training_version.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+import importlib
+import os
+
+import src.paths as paths
+from src.ml.retrain_from_log import retrain_from_log
+
+
+def _write_training_rows(path: Path):
+    rows = [
+        {"timestamp": "2025-01-01T00:00:00Z", "origin": "reddit",  "features": {"burst_z": 1.0}, "label": True},
+        {"timestamp": "2025-01-01T01:00:00Z", "origin": "reddit",  "features": {"burst_z": 0.2}, "label": False},
+        {"timestamp": "2025-01-01T02:00:00Z", "origin": "twitter", "features": {"burst_z": 2.0}, "label": True},
+        {"timestamp": "2025-01-01T03:00:00Z", "origin": "twitter", "features": {"burst_z": 0.1}, "label": False},
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in rows))
+
+
+def test_retrain_writes_version_and_infer_logs(monkeypatch, tmp_path):
+    model_dir = tmp_path / "models"
+    monkeypatch.setattr(paths, "MODELS_DIR", model_dir)
+    td_path = model_dir / "training_data.jsonl"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    _write_training_rows(td_path)
+
+    retrain_from_log(train_log_path=td_path, save_dir=model_dir, version="v-test")
+
+    ver_file = model_dir / "training_version.txt"
+    assert ver_file.exists()
+    assert ver_file.read_text().strip() == "v-test"
+
+    trig_log = model_dir / "trigger_history.jsonl"
+    monkeypatch.setenv("TRIGGER_LOG_PATH", str(trig_log))
+    import src.ml.infer as infer
+    importlib.reload(infer)
+
+    payload = {"origin": "reddit", "features": {"burst_z": 1.5}}
+    infer.infer_score_ensemble(payload, models_dir=model_dir)
+
+    lines = trig_log.read_text().splitlines()
+    assert lines
+    last = json.loads(lines[-1])
+    assert last.get("model_version") == "v-test"
+


### PR DESCRIPTION
## Summary
- Write `training_version.txt` in the models directory during retraining
- Log inference history with the model version and expose a helper to read it
- Include `model_version` in demo trigger history seeding and add regression test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'main')*
- `PYTHONPATH=. pytest -q tmp_test_run.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1751f152c832bbdf877cd858c5793