### PR TITLE
Record retrain version in artifacts

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -157,12 +157,12 @@ jobs:
           print(f"[build-training-data] wrote to {out} (appended matches)")
           PY
 
-      # --- Retrain from training_data.jsonl (versioned v0.5.0) ---
-      - name: Retrain from training data (v0.5.0)
+      # --- Retrain from training_data.jsonl (versioned v0.5.1) ---
+      - name: Retrain from training data (v0.5.1)
         if: ${{ success() }}
         env:
           PYTHONPATH: ${{ github.workspace }}
-          MODEL_VERSION: "v0.5.0"
+          MODEL_VERSION: "v0.5.1"
           TRAIN_LOG_PATH: "models/training_data.jsonl"
           SAVE_MODEL_DIR: "models"
           MODEL_RETRAIN_MIN_ROWS: "1"   # ⬅ low-sample guard
@@ -172,13 +172,13 @@ jobs:
           ls -lah models || true
 
       # --- Upload retrained artifacts (optional) ---
-      - name: Upload retrained model artifacts (v0.5.0)
+      - name: Upload retrained model artifacts (v0.5.1)
         if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
-          name: trigger-likelihood-v050
+          name: trigger-likelihood-v051
           path: |
-            models/v0.5.0/**
+            models/v0.5.1/**
           if-no-files-found: warn
           retention-days: 14
 
@@ -199,6 +199,7 @@ jobs:
           METRICS_MIN_LABELS: "5"
           METRICS_LOOKBACK_HOURS: "72"
           METRICS_MIN_LABELS_ORIGIN: "3"
+          MODEL_VERSION: "v0.5.1"
         run: python scripts/mw_demo_summary.py
 
       - name: Show artifacts (debug)

--- a/scripts/mw_demo_summary.py
+++ b/scripts/mw_demo_summary.py
@@ -10,8 +10,12 @@ import os, json, hashlib, random, uuid
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 
-import matplotlib.pyplot as plt
-from matplotlib.patches import FancyBboxPatch, Rectangle
+try:  # optional plotting dependency
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import FancyBboxPatch, Rectangle
+except Exception:  # pragma: no cover - demo summary can run without matplotlib
+    plt = None
+    FancyBboxPatch = Rectangle = None
 
 from src.analytics.origin_utils import compute_origin_breakdown
 from src.analytics.source_yield import compute_source_yield

--- a/src/ml/retrain_from_log.py
+++ b/src/ml/retrain_from_log.py
@@ -100,6 +100,19 @@ def _write_meta(path: Path, meta: Dict[str, Any]) -> None:
         json.dump(meta, f, indent=2)
 
 
+def _write_training_version_txt(version: str, root: Path) -> None:
+    """Write the version string to root/training_version.txt.
+
+    Silently skips any filesystem errors so retraining doesn't fail just
+    because we cannot persist this helper file.
+    """
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "training_version.txt").write_text(version.strip() + "\n", encoding="utf-8")
+    except Exception:
+        pass
+
+
 def _git_sha() -> str | None:
     try:
         import subprocess
@@ -218,6 +231,7 @@ def retrain_from_log(
     ver = (version or os.getenv("MODEL_VERSION") or "v0.5.0").strip()
     ver_dir = out_root / ver
     ver_dir.mkdir(parents=True, exist_ok=True)
+    _write_training_version_txt(ver, out_root)
 
     rows = _load_jsonl(train_log)
     if not rows:

--- a/src/twitter_ingestor.py
+++ b/src/twitter_ingestor.py
@@ -1,4 +1,7 @@
-import snscrape.modules.twitter as sntwitter
+try:  # optional dependency
+    import snscrape.modules.twitter as sntwitter  # type: ignore
+except Exception:  # pragma: no cover - fallback when snscrape isn't available
+    sntwitter = None
 import os
 import logging
 from datetime import datetime, timedelta
@@ -20,6 +23,8 @@ MOCK_TWEETS = [
 ]
 
 def fetch_from_snscrape(query: str, limit: int = 10):
+    if sntwitter is None:
+        return []
     try:
         tweets = []
         for i, tweet in enumerate(sntwitter.TwitterSearchScraper(query).get_items()):

--- a/tests/test_retrain_version_txt.py
+++ b/tests/test_retrain_version_txt.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+from src.ml import retrain_from_log, training_metadata
+
+
+def _make_rows():
+    rows = []
+    for i in range(4):
+        rows.append({
+            "origin": "reddit",
+            "features": {"f1": float(i)},
+            "label": bool(i % 2),
+        })
+    return rows
+
+
+def test_retrain_writes_version_file(tmp_path, monkeypatch):
+    train_log = tmp_path / "training_data.jsonl"
+    train_log.write_text("\n".join(json.dumps(r) for r in _make_rows()) + "\n")
+
+    # Ensure retrain_from_log and training_metadata use tmp_path as MODELS_DIR
+    monkeypatch.setattr(retrain_from_log, "MODELS_DIR", tmp_path)
+    monkeypatch.setattr(training_metadata, "RUNS_PATH", tmp_path / "training_runs.jsonl")
+
+    retrain_from_log.retrain_from_log(train_log_path=train_log, save_dir=tmp_path, version="vTEST")
+
+    assert (tmp_path / "training_version.txt").read_text().strip() == "vTEST"
+    latest = training_metadata.load_latest_training_metadata(runs_path=tmp_path / "training_runs.jsonl", allow_demo_seed=False)
+    assert latest["version"] == "vTEST"


### PR DESCRIPTION
## Summary
- Write `training_version.txt` during retrains so the selected `MODEL_VERSION` is persisted with the artifacts.
- Pass `MODEL_VERSION=v0.5.1` through the retrain workflow and demo summary steps in CI.
- Guard optional `snscrape`/`matplotlib` imports so tests run without those dependencies.

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c17dd7f318832bb85ed70d056f095e