### PR TITLE
Persist trigger decision history after inference

### DIFF
--- a/scripts/mw_demo_summary.py
+++ b/scripts/mw_demo_summary.py
@@ -10,8 +10,12 @@ import os, json, hashlib, random, uuid
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 
-import matplotlib.pyplot as plt
-from matplotlib.patches import FancyBboxPatch, Rectangle
+try:
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import FancyBboxPatch, Rectangle
+except Exception:  # pragma: no cover - optional in tests
+    plt = None
+    FancyBboxPatch = Rectangle = object
 
 from src.analytics.origin_utils import compute_origin_breakdown
 from src.analytics.source_yield import compute_source_yield
@@ -24,7 +28,6 @@ from src.analytics.burst_detection import compute_bursts
 from src.analytics.volatility_regimes import compute_volatility_regimes
 from src.analytics.threshold_policy import threshold_for_regime
 from src.analytics.nowcast_attention import compute_nowcast_attention
-from src.ml.infer import infer_score, model_metadata, infer_score_ensemble
 from src.ml.thresholds import load_per_origin_thresholds
 from typing import Dict, List
 from src.ml.metrics import rolling_precision_recall_snapshot
@@ -34,7 +37,7 @@ from src.ml.metrics import rolling_precision_recall_snapshot
 _ML_OK = False
 _ML_ERR = None
 try:
-    from src.ml.infer import score as infer_score, model_metadata
+    from src.ml.infer import score as infer_score, model_metadata, infer_score_ensemble
     _ML_OK = True
 except Exception as e:
     _ML_ERR = f"{type(e).__name__}: {e}"

--- a/src/ml/infer.py
+++ b/src/ml/infer.py
@@ -1,6 +1,7 @@
 # src/ml/infer.py
 from __future__ import annotations
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
@@ -22,6 +23,25 @@ _RF_META    = "trigger_likelihood_rf.meta.json"
 _GB_MODEL   = "trigger_likelihood_gb.joblib"
 _GB_META    = "trigger_likelihood_gb.meta.json"
 _TRIGGER_LOG_PATH = Path(os.getenv("TRIGGER_LOG_PATH", MODELS_DIR / "trigger_history.jsonl"))
+
+
+def _model_version_from_meta(meta: Dict[str, Any]) -> str:
+    return str(
+        meta.get("git_sha")
+        or meta.get("model_version")
+        or meta.get("created_at")
+        or "unknown"
+    )
+
+
+def _append_trigger_history(entry: Dict[str, Any]) -> None:
+    try:
+        _TRIGGER_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with _TRIGGER_LOG_PATH.open("a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except Exception as e:
+        # Never break inference if logging fails
+        logging.warning("failed to append trigger history: %s", e)
 
 
 
@@ -100,14 +120,37 @@ def infer_score(payload: Dict[str, Any], *, explain: bool = False, top_n: int = 
     try:
         model, meta = _load_model_and_meta(_LOGI_MODEL, _LOGI_META, models_dir)
     except Exception:
-        if payload.get("features"):
-            bz = float(payload["features"].get("burst_z", 0.0))
-            p = 1 / (1 + np.exp(-0.1 * bz))
-            res = {"prob_trigger_next_6h": float(p), "demo": True}
-            if explain:
-                res["contributions"] = {"burst_z": 0.1 * bz}
-            return res
-        return {"prob_trigger_next_6h": 0.062, "demo": True}
+        feats = payload.get("features") or {}
+        bz = float(feats.get("burst_z", 0.0))
+        proba = 1 / (1 + np.exp(-0.1 * bz))
+        res = {"prob_trigger_next_6h": float(proba), "demo": True}
+        if explain:
+            res["contributions"] = {"burst_z": 0.1 * bz}
+
+        threshold = payload.get("threshold")
+        decision = payload.get("decision")
+        if threshold is None:
+            try:
+                threshold = float(os.getenv("TL_STATIC_PROBA_THR", "0.5"))
+            except Exception:
+                threshold = None
+        if decision is None and threshold is not None:
+            decision = "triggered" if proba >= float(threshold) else "not_triggered"
+
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "origin": payload.get("origin", "unknown"),
+            "adjusted_score": proba,
+            "threshold": threshold,
+            "decision": decision or "unknown",
+            "volatility_regime": payload.get("volatility_regime"),
+            "drifted_features": payload.get("drifted_features") or [],
+            "top_contributors": [{"feature": "burst_z", "contribution": 0.1 * bz}] if explain else [],
+            "model_version": "demo",
+            "features": feats,
+        }
+        _append_trigger_history(entry)
+        return res
 
     feats = payload.get("features")
     if feats is None:
@@ -117,8 +160,36 @@ def infer_score(payload: Dict[str, Any], *, explain: bool = False, top_n: int = 
     x = _vectorize(feats, feat_order)
     proba = float(model.predict_proba(x)[0, 1])
     out = {"prob_trigger_next_6h": proba}
+    top_contrib: List[Dict[str, float]] = []
     if explain:
-        out["contributions"] = _contributions_linear(model, x, feat_order, top_n=top_n)
+        contrib = _contributions_linear(model, x, feat_order, top_n=top_n)
+        out["contributions"] = contrib
+        top_contrib = [{"feature": k, "contribution": v} for k, v in contrib.items()]
+
+    threshold = payload.get("threshold")
+    decision = payload.get("decision")
+    if threshold is None:
+        try:
+            threshold = float(os.getenv("TL_STATIC_PROBA_THR", "0.5"))
+        except Exception:
+            threshold = None
+    if decision is None and threshold is not None:
+        decision = "triggered" if proba >= float(threshold) else "not_triggered"
+
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "origin": payload.get("origin", "unknown"),
+        "adjusted_score": proba,
+        "threshold": threshold,
+        "decision": decision or "unknown",
+        "volatility_regime": payload.get("volatility_regime"),
+        "drifted_features": payload.get("drifted_features") or [],
+        "top_contributors": top_contrib,
+        "model_version": _model_version_from_meta(meta),
+        "features": feats,
+    }
+    _append_trigger_history(entry)
+
     return out
 
 
@@ -130,12 +201,14 @@ def infer_score_ensemble(payload: Dict[str, Any], *, models_dir: Path | None = N
     votes: Dict[str, float] = {}
     demo = False
     feats = payload.get("features") or {}
+    model_version = "unknown"
 
     # logistic
     try:
         L_model, L_meta = _load_model_and_meta(_LOGI_MODEL, _LOGI_META, models_dir)
         order = L_meta.get("feature_order") or []
         votes["logistic"] = float(L_model.predict_proba(_vectorize(feats, order))[0, 1])
+        model_version = _model_version_from_meta(L_meta)
     except Exception:
         pass
 
@@ -166,7 +239,7 @@ def infer_score_ensemble(payload: Dict[str, Any], *, models_dir: Path | None = N
     low = float(min(probs))
     high = float(max(probs))
 
-    return {
+    out = {
         "prob_trigger_next_6h": mean,
         "low": low,
         "high": high,
@@ -175,22 +248,31 @@ def infer_score_ensemble(payload: Dict[str, Any], *, models_dir: Path | None = N
         "demo": demo,
     }
 
-        # --- Append to trigger history log ---
-    try:
-        entry = {
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-            "origin": payload.get("origin", "unknown"),
-            "adjusted_score": out.get("explanation", {}).get("adjusted_score", out["prob_trigger_next_6h"]),
-            "threshold": out.get("explanation", {}).get("threshold_after_volatility", None),
-            "decision": out.get("explanation", {}).get("decision", "unknown"),
-            "volatility_regime": out.get("explanation", {}).get("volatility_regime", None),
-            "drifted_features": out.get("explanation", {}).get("drifted_features", []),
-            "top_contributors": out.get("explanation", {}).get("top_contributors", []),
-        }
-        with _TRIGGER_LOG_PATH.open("a") as f:
-            f.write(json.dumps(entry) + "\n")
-    except Exception:
-        pass
+    threshold = payload.get("threshold")
+    decision = payload.get("decision")
+    if threshold is None:
+        try:
+            threshold = float(os.getenv("TL_STATIC_PROBA_THR", "0.5"))
+        except Exception:
+            threshold = None
+    if decision is None and threshold is not None:
+        decision = "triggered" if mean >= float(threshold) else "not_triggered"
+
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "origin": payload.get("origin", "unknown"),
+        "adjusted_score": mean,
+        "threshold": threshold,
+        "decision": decision or "unknown",
+        "volatility_regime": payload.get("volatility_regime"),
+        "drifted_features": payload.get("drifted_features") or [],
+        "top_contributors": [],
+        "model_version": model_version,
+        "features": feats,
+    }
+    _append_trigger_history(entry)
+
+    return out
 
 
 

--- a/src/twitter_ingestor.py
+++ b/src/twitter_ingestor.py
@@ -1,4 +1,7 @@
-import snscrape.modules.twitter as sntwitter
+try:
+    import snscrape.modules.twitter as sntwitter
+except Exception:  # pragma: no cover - optional dependency may fail on newer Pythons
+    sntwitter = None
 import os
 import logging
 from datetime import datetime, timedelta
@@ -20,6 +23,8 @@ MOCK_TWEETS = [
 ]
 
 def fetch_from_snscrape(query: str, limit: int = 10):
+    if sntwitter is None:
+        return []
     try:
         tweets = []
         for i, tweet in enumerate(sntwitter.TwitterSearchScraper(query).get_items()):
@@ -39,11 +44,20 @@ def fetch_from_snscrape(query: str, limit: int = 10):
 def fetch_from_twitter_api(query: str, limit: int = 10):
     try:
         bearer = os.getenv("TWITTER_BEARER_TOKEN")
+        if not bearer:
+            logging.warning({
+                "event": "twitter_fetch_error",
+                "method": "api",
+                "error": "Missing bearer token",
+                "timestamp": datetime.utcnow().isoformat(),
+            })
+            return []
+
         client = tweepy.Client(bearer_token=bearer)
         resp = client.search_recent_tweets(
             query=query,
             tweet_fields=["created_at", "lang"],
-            max_results=max(limit, 10)
+            max_results=max(10, min(limit, 100))
         )
 
         logging.info({

--- a/tests/test_trigger_history.py
+++ b/tests/test_trigger_history.py
@@ -1,0 +1,44 @@
+import json
+from src.ml import infer
+
+
+def _read_log(path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_logistic_trigger_history(tmp_path):
+    log_file = tmp_path / "log.jsonl"
+    orig = infer._TRIGGER_LOG_PATH
+    infer._TRIGGER_LOG_PATH = log_file
+    try:
+        payload = {"origin": "test", "features": {"burst_z": 1.0}, "threshold": 0.5}
+        infer.infer_score(payload)
+        records = _read_log(log_file)
+        assert len(records) == 1
+        rec = records[0]
+        for key in ("model_version", "threshold", "decision", "features"):
+            assert key in rec
+        assert rec["features"] == payload["features"]
+    finally:
+        infer._TRIGGER_LOG_PATH = orig
+        if log_file.exists():
+            log_file.unlink()
+
+
+def test_ensemble_trigger_history(tmp_path):
+    log_file = tmp_path / "log.jsonl"
+    orig = infer._TRIGGER_LOG_PATH
+    infer._TRIGGER_LOG_PATH = log_file
+    try:
+        payload = {"origin": "test", "features": {"burst_z": 1.0}, "threshold": 0.5}
+        infer.infer_score_ensemble(payload)
+        records = _read_log(log_file)
+        assert len(records) == 1
+        rec = records[0]
+        for key in ("model_version", "threshold", "decision", "features"):
+            assert key in rec
+        assert rec["features"] == payload["features"]
+    finally:
+        infer._TRIGGER_LOG_PATH = orig
+        if log_file.exists():
+            log_file.unlink()


### PR DESCRIPTION
## Summary
- guard ML imports in demo summary so optional modules do not break execution
- warn when trigger history cannot be written and always log demo fallback entries
- clamp Twitter API requests within limits and skip when bearer token is missing
- add tests covering trigger history logging for logistic and ensemble inference paths

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c18fb7c524832badc4ed4f2adef712